### PR TITLE
Add basic auth middleware

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -86,6 +86,11 @@ export default defineNuxtConfig({
         clientSecret: ''
       }
     },
+    basicAuth: {
+      username: '',
+      password: '',
+      enabled: false
+    },
     public: {
       isDataMocked: false,  // can be overridden by NUXT_PUBLIC_IS_DATA_MOCKED environment variable
       scope: 'organization',  // can be overridden by NUXT_PUBLIC_SCOPE environment variable

--- a/server/middleware/basic-auth.ts
+++ b/server/middleware/basic-auth.ts
@@ -1,0 +1,24 @@
+import { createError, getHeader } from 'h3'
+
+export default defineEventHandler((event) => {
+  const config = useRuntimeConfig(event)
+  if (!config.basicAuth?.enabled) {
+    return
+  }
+
+  const authHeader = getHeader(event, 'authorization')
+  if (!authHeader || !authHeader.startsWith('Basic ')) {
+    event.node.res.setHeader('WWW-Authenticate', 'Basic realm="Protected"')
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const credentials = Buffer.from(authHeader.split(' ')[1], 'base64').toString()
+  const [username, password] = credentials.split(':')
+  if (
+    username !== config.basicAuth.username ||
+    password !== config.basicAuth.password
+  ) {
+    event.node.res.setHeader('WWW-Authenticate', 'Basic realm="Protected"')
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+})


### PR DESCRIPTION
## Summary
- enable optional username/password authentication
- add middleware for Basic Auth

## Testing
- `npm test` *(fails: could not fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68404f481a808329afc90cc488a5cc2f