### PR TITLE
Add basic auth settings

### DIFF
--- a/.env
+++ b/.env
@@ -27,3 +27,8 @@ NUXT_OAUTH_GITHUB_CLIENT_SECRET=
 
 # to use a corporate proxy
 # HTTP_PROXY=http://proxy.company.com:8080
+
+# Optional Basic Authentication
+#NUXT_BASIC_AUTH_ENABLED=false
+#NUXT_BASIC_AUTH_USERNAME=
+#NUXT_BASIC_AUTH_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ Solution supports HTTP Proxy settings when running in corporate environment. Sim
 
 For custom CA use environment variable `CUSTOM_CA_PATH` to load the certificate into proxy agent options.
 
+#### Optional Basic Authentication
+
+Protect access to the dashboard with a username and password.
+
+````
+NUXT_BASIC_AUTH_ENABLED=true
+NUXT_BASIC_AUTH_USERNAME=myuser
+NUXT_BASIC_AUTH_PASSWORD=mysecret
+````
+
+Set `NUXT_BASIC_AUTH_ENABLED` to `true` to require credentials on every request.
+
 ## Install Dependencies
 
 ```bash

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -86,6 +86,11 @@ export default defineNuxtConfig({
         clientSecret: ''
       }
     },
+    basicAuth: {
+      username: '',
+      password: '',
+      enabled: false
+    },
     public: {
       isDataMocked: false,  // can be overridden by NUXT_PUBLIC_IS_DATA_MOCKED environment variable
       scope: 'organization',  // can be overridden by NUXT_PUBLIC_SCOPE environment variable

--- a/server/middleware/basic-auth.ts
+++ b/server/middleware/basic-auth.ts
@@ -1,0 +1,26 @@
+import { createError, getHeader } from 'h3'
+
+export default defineEventHandler((event) => {
+  const config = useRuntimeConfig(event)
+  const enabled =
+    config.basicAuth?.enabled === true || config.basicAuth?.enabled === 'true'
+  if (!enabled) {
+    return
+  }
+
+  const authHeader = getHeader(event, 'authorization')
+  if (!authHeader || !authHeader.startsWith('Basic ')) {
+    event.node.res.setHeader('WWW-Authenticate', 'Basic realm="Protected"')
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const credentials = Buffer.from(authHeader.split(' ')[1], 'base64').toString()
+  const [username, password] = credentials.split(':')
+  if (
+    username !== config.basicAuth.username ||
+    password !== config.basicAuth.password
+  ) {
+    event.node.res.setHeader('WWW-Authenticate', 'Basic realm="Protected"')
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+})


### PR DESCRIPTION
## Summary
- allow enabling Basic Auth when NUXT_BASIC_AUTH_ENABLED=true
- document env variables for username/password protection

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68404f481a808329afc90cc488a5cc2f